### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,17 +2,17 @@
 # Datatypes (KEYWORD1)
 #######################################
  
-ArduinoML KEYWORD1
+ArduinoML	KEYWORD1
  
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
  
-begin    KEYWORD2
-train KEYWORD2
-predict KEYWORD2
-evaluate KEYWORD2
-setHyperParameters KEYWORD2
+begin	KEYWORD2
+train	KEYWORD2
+predict	KEYWORD2
+evaluate	KEYWORD2
+setHyperParameters	KEYWORD2
  
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords